### PR TITLE
Handle explicit undefined values

### DIFF
--- a/test.js
+++ b/test.js
@@ -77,3 +77,12 @@ jsonDoubleQuote._object2 = mapKeys(jsonDoubleQuote._object2, (_, key) => key.rep
 const luaDoubleQuote = lua.replace(/'/g, '"')
 equal(format(jsonDoubleQuote, { singleQuote: false }), luaDoubleQuote)
 deepEqual(parse(luaDoubleQuote), jsonDoubleQuote)
+
+const jsonUndefinedValue = {
+  _undefined: undefined,
+  _string: 'string',
+}
+const luaUndefinedValue = `return {
+  _string = 'string',
+}`
+equal(format(jsonUndefinedValue), luaUndefinedValue)


### PR DESCRIPTION
In JSON, you can explicitly define a value as `undefined`:

```js
{ _undefined: undefined }
```

When running the `format` function against the above object, the following error is observed:

```bash
/Users/dean/projects/lua-json/index.js:53
    throw new Error(`can't format ${typeof value}`)
    ^

Error: can't format undefined
    at rec (/Users/dean/projects/lua-json/index.js:53:11)
    at /Users/dean/projects/lua-json/index.js:46:79
    at Array.map (<anonymous>)
    at rec (/Users/dean/projects/lua-json/index.js:46:12)
    at format (/Users/dean/projects/lua-json/index.js:56:47)
    at Object.<anonymous> (/Users/dean/projects/lua-json/test.js:70:7)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
```

This commit adds the missing safeguard against any explicit undefined values which prevents the fall through to `throw new Error('can't format ${typeof value}')`. ~~Adding this surfaces a small issue wherein `\n\n` is written to the formatted string. As far as I can tell, this is due to the way the `${eol}` is prepended (rather than appended) to each line. There is a `.replace` method call to take care of the `\n\n`, however, this has a limit. For example, `\n\n\n` would still become `\n\n`.~~

~~Even accounting for the above double-line issue, this does fix the fatal error when dealing with `undefined` values and still produces a valid Lua string.~~

Edit: I solved the above with a simple `do...while` loop.

A specific test case was added because the shape of the JSON and Lua are not interchangeable. For example:

```js
format({ _undefined: undefined, _string: 'string' }) // -> 'return { _string = "string" }'
parse('return { _string = "string" }') // -> { _string: 'string' }
```